### PR TITLE
Changes to Terratest script

### DIFF
--- a/test/terraform_test.go
+++ b/test/terraform_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TerraformAzureTest(t *testing.T) {
+func TestTerraformAzure(t *testing.T) {
 	t.Parallel()
 
 	subscriptionID := "" // subscriptionID is overridden by the environment variable "ARM_SUBSCRIPTION_ID"

--- a/test/terratest_aks.go
+++ b/test/terratest_aks.go
@@ -1,0 +1,23 @@
+package terraform
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TerraTestAzureAKS(t *testing.T, o *terraform.Options, tfEnvironment string, uniquePostfix string, resourceGroupName string, subscriptionID string) {
+	// Expected output
+	expectedClusterName := fmt.Sprintf("aks-cluster-%s-%s", tfEnvironment, uniquePostfix)
+	expectedClusterLocation := "westeurope"
+
+	aksClusterName := terraform.Output(t, o, "aks_cluster_name")
+	actualAksCluster, _ := azure.GetManagedClusterE(t, resourceGroupName, aksClusterName, subscriptionID)
+
+	// Verify AKS Creation
+	assert.Equal(t, expectedClusterName, *(*&actualAksCluster.Name), "AKS cluster names do not match.")
+	assert.Equal(t, expectedClusterLocation, *(*&actualAksCluster.Location), "Azure location is not correct.")
+}

--- a/test/terratest_resourcegroup.go
+++ b/test/terratest_resourcegroup.go
@@ -1,0 +1,17 @@
+package terraform
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/azure"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TerraTestAzureResourceGroup(t *testing.T, o *terraform.Options, resourceGroupName string, subscriptionID string) {
+	// Verify the items exists
+	existsAksResourceGroup := azure.ResourceGroupExists(t, resourceGroupName, subscriptionID)
+
+	// Verify Resource Group creation
+	assert.True(t, existsAksResourceGroup, "Resource group does not exist")
+}


### PR DESCRIPTION
This does not work, since the testfuncs can only receive `*testing.T`. I am just curious to whether there is a way of making it work :)

Error code received while trying to run is:
```bash
wrong signature for TestTerraformAzureResourceGroup, must be: func TestTerraformAzureResourceGroup(t *testing.T)
```
